### PR TITLE
Created api guides subdir and moved content

### DIFF
--- a/source/api/guides/index.html.md
+++ b/source/api/guides/index.html.md
@@ -1,0 +1,25 @@
+---
+title: BigCommerce API Documentation
+layout: "apitwocolumn"
+
+toc_footers:
+  - <a href="/">Home</a>
+  - <a href="/api/">API - Basics</a>
+  - <a href="/themes/">Themes</a>
+  - <a href="https://stencil.bigcommerce.com/docs/" target="_blank"> &nbsp;  Stencil Themes</a>
+  - <a href="/themes/blueprint/"> &nbsp; Blueprint Themes</a>
+  - <a href="http://goo.gl/forms/380FmYFlaJ05CL3q2" target="_blank">Sign Up for the Developer Newsletter</a>
+  - <a href="http://github.com/tripit/slate" target="_blank">Site Built with Slate</a>
+
+includes:
+  - tut_postman_oauth
+  - api_guides_curl_quickstart
+
+search: true
+---
+
+# <span class="jumptarget"> Quickstart Guides for Developing on BigCommerce </span>
+
+BigCommerce is an ecommerce platform with a flexible API to allow you create technical solutions for businesses in the language of your choice. 
+
+We believe starting development on a project with our platform should be easy, so whether you have built with APIs or used our templating engine before, we want you to have the tools to start your project efficiently.

--- a/source/api/index.html.md
+++ b/source/api/index.html.md
@@ -41,8 +41,6 @@ includes:
   - api_legacy_basic_auth
   - api_rate_limits_basic
   - api_guides_oauth_transition
-  - api_guides_curl_quickstart
-  - tut_postman_oauth
   - api_storefront_apps_root
   - api_customer_login
   - api_current_customer

--- a/source/includes/_api_basic_auth_tokens.md
+++ b/source/includes/_api_basic_auth_tokens.md
@@ -48,4 +48,4 @@ To change the API token that an app is using to access a store, use the followin
 
 ### <span class="jumptarget" id="request_basic"> Making an API Request with Basic Auth </span>
 
-Many tools are available to interact with APIs. For example, to see how to quickly make initial requests using <a href="https://en.wikipedia.org/wiki/CURL" target="_blank">cURL</a> commands, please see our [cURL Quickstart Guide](#curl-quickstart-guide).
+Many tools are available to interact with APIs. For example, to see how to quickly make initial requests using <a href="https://en.wikipedia.org/wiki/CURL" target="_blank">cURL</a> commands, please see our [cURL Quickstart Guide](/api/guides#curl-quickstart-guide).

--- a/source/includes/_api_guides_curl_quickstart.md
+++ b/source/includes/_api_guides_curl_quickstart.md
@@ -1,6 +1,6 @@
 # <span class="jumptarget" id="curl_quickstart"> cURL Quickstart Guide </span>
 
-This section provides some sample cURL commands, for quickstart purposes. These use Basic Authentication, so before you can issue these commands, you must generate Basic Authentication credentials by following the steps discussed [here](#pvt_token). Once you have your Basic Authentication credentials, you can issue cURL commands as listed below.
+This section provides some sample cURL commands, for quickstart purposes. These use Basic Authentication, so before you can issue these commands, you must generate Basic Authentication credentials by following the steps discussed [here](/api#pvt_token). Once you have your Basic Authentication credentials, you can issue cURL commands as listed below.
 
 ```
     curl --request GET \

--- a/source/includes/_api_oauth_tokens.md
+++ b/source/includes/_api_oauth_tokens.md
@@ -63,4 +63,4 @@ There is no undo, so be sure before you delete an account. You can also use the 
 
 ### <span class="jumptarget" id="request_oauth"> Making an API Request with OAuth </span>
 
-To see how to quickly make initial OAuth requests using the <a href="https://www.getpostman.com/" target="_blank">Postman app</a>, please see our [Postman/OAuth Quickstart Guide](#postman_qs).
+To see how to quickly make initial OAuth requests using the <a href="https://www.getpostman.com/" target="_blank">Postman app</a>, please see our [Postman/OAuth Quickstart Guide](/api/guides/#postman_qs).

--- a/source/includes/_tut_postman_oauth.md
+++ b/source/includes/_tut_postman_oauth.md
@@ -6,7 +6,7 @@ To get started, you'll need OAuth credentials to supply to Postman. BigCommerce 
 
 ## <span class="jumptarget"> Creating OAuth2.0 Credentials </span>
 
-Create your OAuth 2.0 credentials as described above under [Obtaining OAuth Tokens](#cp_oauth_get). (Depending on what scopes you set, you will be limited in what objects you can request. You can view scope information [here](/api/#oauth-scopes).)
+Create your OAuth 2.0 credentials as described above under [Obtaining OAuth Tokens](/api#cp_oauth_get). (Depending on what scopes you set, you will be limited in what objects you can request. You can view scope information [here](/api#oauth-scopes).)
 
 ## <span class="jumptarget"> Postman Setup </span>
 
@@ -28,8 +28,8 @@ Next, add these two key/value pairs, using the OAuth credentials you obtained in
 
 | Key | Value |
 |---|---|
-| `X-Auth-Client` | The **Client ID** you obtained when you [created your OAuth token](/#cp_oauth_get). |
-| `X-Auth-Token` | The **Access Token** string you obtained when you [created your OAuth token](#cp_oauth_get). |
+| `X-Auth-Client` | The **Client ID** you obtained when you [created your OAuth token](/api#cp_oauth_get). |
+| `X-Auth-Token` | The **Access Token** string you obtained when you [created your OAuth token](/api#cp_oauth_get). |
 
 
 ## <span class="jumptarget" id="post_setup"> Sending a Request </span>
@@ -40,12 +40,12 @@ We have created a collection of Postman requests for our v3 API, which you can i
 
 To use this collection, you'll need to enter your OAuth credentials, as explained above under [Postman Setup](#post_setup).
  
-You'll also need to enter your store's API Path, as displayed in the [control panel](#cp_oauth_get). You can do so in either of these days:
+You'll also need to enter your store's API Path, as displayed in the [control panel](/api#cp_oauth_get). You can do so in either of these days:
 
 * Within each endpoint, replace the variable `{{store_hash}}`; or 
 
 * Add a new environment, in which you create a  `store_hash` key, then set its value to the alpahnumeric string from your API Path. (For&#160;details on setting up a Postman environment, see [this Postman documentation](https://www.getpostman.com/docs/environments).)
 
-Now you can send and receive information through an OAuth API connection with BigCommerce. If you'd like to register webhooks through Postman, please see [Creating Webhooks: Sending the POST Request](/api/#creating-webhooks-sending-the-post-request). 
+Now you can send and receive information through an OAuth API connection with BigCommerce. If you'd like to register webhooks through Postman, please see [Creating Webhooks: Sending the POST Request](/api#creating-webhooks-sending-the-post-request). 
 
 

--- a/source/layouts/404.erb
+++ b/source/layouts/404.erb
@@ -44,12 +44,29 @@ under the License.
       <div class="topBar-container topBar-container--fixed">
         <nav class="top-bar ng-isolate-scope" ng-transclude="" top-bar="" style="height: 81px;">
           <ul class="title-area ng-scope">
-            <li class="name"><a href="/"><img src="//developer.bigcommerce.com/images/developer.png" /></a></li>
+            <li class="name"><%= link_to image_tag("developer.png"), "/" %></li>
           </ul>
           <section class="top-bar-section ng-scope">
             <ul class="menuItems">
-              <li><a href="/api/" title="API">API</a></li>
-              <li><a href="/themes/" title="Themes">Themes</a></li>
+              <li class="dropdown">
+                <div class="dropbtn" title="API">API</div>
+                <div class="dropdown-content">
+                  <a href="/api">Basics</a>
+                  <a href="/api/v2">API V2</a>
+                  <a href="https://github.com/bigcommerce/api/blob/master/docs/v3-catalog.md">API V3</a>
+                  <a href="/api/guides">Guides</a>
+                </div>
+              </li>
+              <li>
+                <li class="dropdown">
+                <div class="dropbtn" title="Themes">THEMES</div>
+                <div class="dropdown-content">
+                  <a href="/themes">Basics</a>
+                  <a href="http://stencil.bigcommerce.com/docs">Stencil</a>
+                  <a href="/themes/blueprint">Blueprint</a>
+                </div>
+              </li>
+              </li>
               <li><a href="/changelog/" title="Changelog">Changelog</a></li>
               <li><a href="/support/" title="Help and Support">Support</a></li>
             </ul>

--- a/source/layouts/_navbar.html.erb
+++ b/source/layouts/_navbar.html.erb
@@ -9,6 +9,7 @@
           <div class="dropbtn" title="API">API</div>
           <div class="dropdown-content">
             <a href="/api">Basics</a>
+            <a href="/api/guides">Guides</a>
             <a href="/api/v2">API V2</a>
             <a href="https://github.com/bigcommerce/api/blob/master/docs/v3-catalog.md">API V3</a>
           </div>

--- a/source/layouts/apitwocolumn.erb
+++ b/source/layouts/apitwocolumn.erb
@@ -65,9 +65,9 @@ under the License.
         <div class="nav-label">API Docs</div>
         <div class="api-selector btn-group">
           <a href="/api/" class="btn btn-default" data-page-name="home">Basics</a>
+          <a href="/api/guides/" class="btn btn-default" data-page-name="Guides">Guides</a>
           <a href="/api/v2/" class="btn btn-default" data-page-name="V2">V2</a>
           <a href="https://github.com/bigcommerce/api/blob/master/docs/v3-catalog.md" target="_blank" class="btn btn-default" data-page-name="V3">V3</a>
-          <a href="/themes/" class="btn btn-default" data-page-name="Themes">Themes</a>
         </div>
         <div class="clear"></div>
       <% if language_tabs %>

--- a/source/stylesheets/_custom.scss
+++ b/source/stylesheets/_custom.scss
@@ -139,7 +139,7 @@
   }
 }
 
-#changelog, #api-documentation, #understanding-themes, #api-v2-documentation, #api-v3-documentation, #blueprint-themes, #blueprint-theme-snippets, #blueprint-theme-layouts, #blueprint-theme-panels {
+#changelog, #api-documentation, #understanding-themes, #api-v2-documentation, #api-v3-documentation, #blueprint-themes, #blueprint-theme-snippets, #blueprint-theme-layouts, #blueprint-theme-panels, #quickstart-guides-for-developing-on-bigcommerce {
   @extend %header-font;
   color: #4f75f8 !important;
   font-size: 1.55556rem !important;
@@ -334,4 +334,14 @@ li.dropdown {
 
 li a, .tocify-wrapper {
   text-align: left;
+}
+
+.api_v3 {
+  pre {
+    width:40%;
+  }
+
+  .content table {
+    width: 55% !important;
+  }
 }


### PR DESCRIPTION
#### What?

Moving quickstart/guide content to respective directory for SEO benefit and discoverability within the site

#### How To Test

Verify images, links, and content is available under /api/guides and that navigation dropdown is functional on 404s and all other pages. 

#### Screenshots (if appropriate)

![screen shot 2017-02-01 at 10 44 52 am](https://cloud.githubusercontent.com/assets/9373485/22516514/a35c6f7c-e86b-11e6-8652-2254dd5dce3b.png)
