### PR TITLE
Updated swagger to md generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 .cache
 .vagrant
 .sass-cache
+/node_modules
 
 # YARD artifacts
 .yardoc

--- a/source/api/v3/openapi-cart.html.md
+++ b/source/api/v3/openapi-cart.html.md
@@ -1,12 +1,8 @@
 ---
 title: Order API v2.0.0
-layout: "layout"
+layout: "apitwocolumn"
 language_tabs:
-  - shell
-  - python
-  - java
-  - ruby
-  - javascript
+  - ''
 toc_footers: []
 includes: []
 search: true
@@ -28,67 +24,6 @@ Base URL = ://undefined/
 ## POST /billing
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post ://undefined/billing
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/billing', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post '://undefined/billing', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('://undefined/billing', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/billing");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Add / Update the billing address in quote object
 
@@ -125,67 +60,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get ://undefined/cart
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/cart', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get '://undefined/cart', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('://undefined/cart', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/cart");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 *Retrieve cart data*
 
 Retrieves a cart, which is the composition of set of items
@@ -211,67 +85,6 @@ This operation does not require authentication
 ## POST /coupon
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post ://undefined/coupon
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/coupon', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post '://undefined/coupon', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('://undefined/coupon', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/coupon");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Adding coupon or gift certificate code to the cart
 
@@ -308,67 +121,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete ://undefined/coupon/{couponCode}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/coupon/{couponCode}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete '://undefined/coupon/{couponCode}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('://undefined/coupon/{couponCode}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/coupon/{couponCode}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 Removing coupon or gift certificate code from the cart
 
 ### Parameters
@@ -398,67 +150,6 @@ This operation does not require authentication
 ## POST /customer
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post ://undefined/customer
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/customer', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post '://undefined/customer', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('://undefined/customer', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/customer");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Associate the quote object to a customer. Parameters are comma separated as values against `includes` key. For example, `/quote?includes=customer,shippingOptions`
 
@@ -497,67 +188,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get ://undefined/customer
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/customer', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get '://undefined/customer', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('://undefined/customer', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/customer");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 currently any GET request to /customer end point will result to a `405` response because `getAction()` method does't exists
 
 ### Parameters
@@ -587,67 +217,6 @@ This operation does not require authentication
 ## DELETE /customer
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X delete ://undefined/customer
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/customer', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete '://undefined/customer', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('://undefined/customer', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/customer");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Remove customer information from the quote.
 
@@ -682,67 +251,6 @@ This operation does not require authentication
 ## POST /order
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post ://undefined/order
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/order', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post '://undefined/order', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('://undefined/order', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/order");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Used to create an order (currently we use session to retrieve quote data)
 
@@ -787,67 +295,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get ://undefined/order/{orderId}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/order/{orderId}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get '://undefined/order/{orderId}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('://undefined/order/{orderId}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/order/{orderId}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 *Retrieve order data*
 
 Retrieves an order, which is the composition of set of items
@@ -879,67 +326,6 @@ This operation does not require authentication
 ## POST /order/{orderId}
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post ://undefined/order/{orderId}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/order/{orderId}', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post '://undefined/order/{orderId}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('://undefined/order/{orderId}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/order/{orderId}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Update the order. Finalize in case the order has been set previously in checkout
 
@@ -1035,67 +421,6 @@ This operation does not require authentication
 ## POST /order/{orderId}/payment
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post ://undefined/order/{orderId}/payment
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/order/{orderId}/payment', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post '://undefined/order/{orderId}/payment', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('://undefined/order/{orderId}/payment', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/order/{orderId}/payment");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Update the payment and order status from payment service (BigPay) & finalize the order. Requires HAWK authentication.
 
@@ -1211,67 +536,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get ://undefined/payments
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/payments', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get '://undefined/payments', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('://undefined/payments', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/payments");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 Retrieve a list of existing payment methods
 
 ### Responses
@@ -1292,67 +556,6 @@ This operation does not require authentication
 ## GET /payments/{providerId}
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get ://undefined/payments/{providerId}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/payments/{providerId}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get '://undefined/payments/{providerId}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('://undefined/payments/{providerId}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/payments/{providerId}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Retrieve a single, existing payment method
 
@@ -1382,67 +585,6 @@ This operation does not require authentication
 ## GET /quote
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get ://undefined/quote
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/quote', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get '://undefined/quote', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('://undefined/quote', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/quote");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Parameters are comma separated as values against `includes` key. For example, `/quote?includes=customer,shippingOptions`
 
@@ -1478,67 +620,6 @@ This operation does not require authentication
 ## POST /shipping
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post ://undefined/shipping
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/shipping', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post '://undefined/shipping', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('://undefined/shipping', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/shipping");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 Add / Update the shipping address in quote object
 
@@ -1577,67 +658,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get ://undefined/shippingOptions
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/shippingOptions', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get '://undefined/shippingOptions', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('://undefined/shippingOptions', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/shippingOptions");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 *Retrieve Shipping Options*
 
 Retrieves a list of all available shipping options for the current quote
@@ -1669,67 +689,6 @@ This operation does not require authentication
 ## PUT /shippingOptions
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put ://undefined/shippingOptions
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('://undefined/shippingOptions', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put '://undefined/shippingOptions', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('://undefined/shippingOptions', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("://undefined/shippingOptions");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 *Set Shipping Option*
 

--- a/source/api/v3/openapi-cart.html.md
+++ b/source/api/v3/openapi-cart.html.md
@@ -2,13 +2,11 @@
 title: Order API v2.0.0
 layout: "layout"
 language_tabs:
-  - shell: Shell
-  - http: HTTP
-  - html: JavaScript
-  - javascript: Node.JS
-  - python: Python
-  - ruby: Ruby
-  - java: Java
+  - shell
+  - python
+  - java
+  - ruby
+  - javascript
 toc_footers: []
 includes: []
 search: true
@@ -32,27 +30,9 @@ Base URL = ://undefined/
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post ://undefined/billing
-````
-
-````http
-POST ://undefined/billing HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/billing',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -80,7 +60,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('://undefined/billing', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('://undefined/billing', headers=headers, params={
   # TODO
 })
 
@@ -139,27 +126,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get ://undefined/cart
-````
-
-````http
-GET ://undefined/cart HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/cart',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -187,7 +156,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('://undefined/cart', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('://undefined/cart', headers=headers, params={
   # TODO
 })
 
@@ -237,27 +213,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post ://undefined/coupon
-````
-
-````http
-POST ://undefined/coupon HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/coupon',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -285,7 +243,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('://undefined/coupon', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('://undefined/coupon', headers=headers, params={
   # TODO
 })
 
@@ -344,27 +309,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete ://undefined/coupon/{couponCode}
-````
-
-````http
-DELETE ://undefined/coupon/{couponCode} HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/coupon/{couponCode}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -392,7 +339,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('://undefined/coupon/{couponCode}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('://undefined/coupon/{couponCode}', headers=headers, params={
   # TODO
 })
 
@@ -446,27 +400,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post ://undefined/customer
-````
-
-````http
-POST ://undefined/customer HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/customer',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -494,7 +430,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('://undefined/customer', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('://undefined/customer', headers=headers, params={
   # TODO
 })
 
@@ -555,27 +498,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get ://undefined/customer
-````
-
-````http
-GET ://undefined/customer HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/customer',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -603,7 +528,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('://undefined/customer', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('://undefined/customer', headers=headers, params={
   # TODO
 })
 
@@ -657,27 +589,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete ://undefined/customer
-````
-
-````http
-DELETE ://undefined/customer HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/customer',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -705,7 +619,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('://undefined/customer', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('://undefined/customer', headers=headers, params={
   # TODO
 })
 
@@ -763,27 +684,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post ://undefined/order
-````
-
-````http
-POST ://undefined/order HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/order',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -811,7 +714,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('://undefined/order', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('://undefined/order', headers=headers, params={
   # TODO
 })
 
@@ -878,27 +788,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get ://undefined/order/{orderId}
-````
-
-````http
-GET ://undefined/order/{orderId} HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/order/{orderId}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -926,7 +818,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('://undefined/order/{orderId}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('://undefined/order/{orderId}', headers=headers, params={
   # TODO
 })
 
@@ -982,27 +881,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post ://undefined/order/{orderId}
-````
-
-````http
-POST ://undefined/order/{orderId} HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/order/{orderId}',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1030,7 +911,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('://undefined/order/{orderId}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('://undefined/order/{orderId}', headers=headers, params={
   # TODO
 })
 
@@ -1149,27 +1037,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post ://undefined/order/{orderId}/payment
-````
-
-````http
-POST ://undefined/order/{orderId}/payment HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/order/{orderId}/payment',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1197,7 +1067,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('://undefined/order/{orderId}/payment', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('://undefined/order/{orderId}/payment', headers=headers, params={
   # TODO
 })
 
@@ -1335,27 +1212,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get ://undefined/payments
-````
-
-````http
-GET ://undefined/payments HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/payments',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1383,7 +1242,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('://undefined/payments', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('://undefined/payments', headers=headers, params={
   # TODO
 })
 
@@ -1428,27 +1294,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get ://undefined/payments/{providerId}
-````
-
-````http
-GET ://undefined/payments/{providerId} HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/payments/{providerId}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1476,7 +1324,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('://undefined/payments/{providerId}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('://undefined/payments/{providerId}', headers=headers, params={
   # TODO
 })
 
@@ -1529,27 +1384,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get ://undefined/quote
-````
-
-````http
-GET ://undefined/quote HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/quote',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1577,7 +1414,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('://undefined/quote', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('://undefined/quote', headers=headers, params={
   # TODO
 })
 
@@ -1636,27 +1480,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post ://undefined/shipping
-````
-
-````http
-POST ://undefined/shipping HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/shipping',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1684,7 +1510,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('://undefined/shipping', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('://undefined/shipping', headers=headers, params={
   # TODO
 })
 
@@ -1745,27 +1578,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get ://undefined/shippingOptions
-````
-
-````http
-GET ://undefined/shippingOptions HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/shippingOptions',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1793,7 +1608,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('://undefined/shippingOptions', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('://undefined/shippingOptions', headers=headers, params={
   # TODO
 })
 
@@ -1849,27 +1671,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put ://undefined/shippingOptions
-````
-
-````http
-PUT ://undefined/shippingOptions HTTP/1.1
-Host: undefined
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: '://undefined/shippingOptions',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1897,7 +1701,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('://undefined/shippingOptions', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('://undefined/shippingOptions', headers=headers, params={
   # TODO
 })
 

--- a/source/api/v3/openapi-catalog.html.md
+++ b/source/api/v3/openapi-catalog.html.md
@@ -1,12 +1,8 @@
 ---
 title: BigCommerce Catalog API v3.0.0b
-layout: "layout"
+layout: "apitwocolumn"
 language_tabs:
-  - shell
-  - python
-  - java
-  - ruby
-  - javascript
+  - ''
 toc_footers: []
 includes: []
 search: true
@@ -30,67 +26,6 @@ BigCommerce Catalog API Definition.
 ## getProducts
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products`
 
@@ -413,67 +348,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `POST /catalog/products`
 
 Creates a `Product` in the BigCommerce Catalog.
@@ -775,67 +649,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/products`
 
 Deletes one or more `Product` objects from the BigCommerce Catalog.
@@ -922,67 +735,6 @@ This operation does not require authentication
 ## getProductById
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}`
 
@@ -1177,67 +929,6 @@ This operation does not require authentication
 ## updateProduct
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/products/{product_id}`
 
@@ -1549,67 +1240,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/products/{product_id}`
 
 Deletes a `Product` object from the BigCommerce Catalog.
@@ -1640,67 +1270,6 @@ This operation does not require authentication
 ## getProductImages
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/images`
 
@@ -1777,67 +1346,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `POST /catalog/products/{product_id}/images`
 
 Creates an image on a product. Publically accessible URLs and files (form post) are valid parameters.
@@ -1913,67 +1421,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `GET /catalog/products/{product_id}/images/{image_id}`
 
 Gets image on a product.
@@ -2037,67 +1484,6 @@ This operation does not require authentication
 ## updateProductImage
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/products/{product_id}/images/{image_id}`
 
@@ -2176,67 +1562,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/products/{product_id}/images/{image_id}`
 
 Deletes a `ProductImage` in the BigCommerce Catalog.
@@ -2271,67 +1596,6 @@ This operation does not require authentication
 ## getProductVideos
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/videos`
 
@@ -2391,67 +1655,6 @@ This operation does not require authentication
 ## createProductVideo
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/products/{product_id}/videos`
 
@@ -2524,67 +1727,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `GET /catalog/products/{product_id}/videos/{video_id}`
 
 Gets video on a product.
@@ -2644,67 +1786,6 @@ This operation does not require authentication
 ## updateProductVideo
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/products/{product_id}/videos/{video_id}`
 
@@ -2779,67 +1860,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/products/{product_id}/videos/{video_id}`
 
 Deletes a `ProductVideo` in the BigCommerce Catalog.
@@ -2874,67 +1894,6 @@ This operation does not require authentication
 ## getVariantsByProductId
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/variants`
 
@@ -3028,67 +1987,6 @@ This operation does not require authentication
 ## createVariant
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/products/{product_id}/variants`
 
@@ -3189,67 +2087,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `GET /catalog/products/{product_id}/variants/{variant_id}`
 
 Gets a `Variant` object.
@@ -3324,67 +2161,6 @@ This operation does not require authentication
 ## updateVariant
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/products/{product_id}/variants/{variant_id}`
 
@@ -3482,67 +2258,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/products/{product_id}/variants/{variant_id}`
 
 Deletes a `Variant`.
@@ -3577,67 +2292,6 @@ This operation does not require authentication
 ## getVariantMetafieldsByProductIdAndVariantId
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/variants/{variant_id}/metafields`
 
@@ -3698,8 +2352,8 @@ Status|Meaning|Description
       "resource_type": "category",
       "resource_id": 0,
       "id": 0,
-      "created_at": "2017-02-07T18:24:53Z",
-      "updated_at": "2017-02-07T18:24:53Z"
+      "created_at": "2017-02-07T19:44:56Z",
+      "updated_at": "2017-02-07T19:44:56Z"
     }
   ],
   "meta": {
@@ -3731,67 +2385,6 @@ This operation does not require authentication
 ## createVariantMetafield
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/products/{product_id}/variants/{variant_id}/metafields`
 
@@ -3853,8 +2446,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -3890,67 +2483,6 @@ This operation does not require authentication
 ## getVariantMetafieldByProductIdAndVariantId
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}`
 
@@ -3998,8 +2530,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -4019,67 +2551,6 @@ This operation does not require authentication
 ## updateVariantMetafield
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}`
 
@@ -4144,8 +2615,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -4165,67 +2636,6 @@ This operation does not require authentication
 ## deleteVariantMetafieldById
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `DELETE /catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}`
 
@@ -4265,67 +2675,6 @@ This operation does not require authentication
 ## createVariantImage
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "multipart/form-data",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/products/{product_id}/variants/{variant_id}/image`
 
@@ -4396,67 +2745,6 @@ This operation does not require authentication
 ## getOptions
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/options`
 
@@ -4563,67 +2851,6 @@ This operation does not require authentication
 ## createOption
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/products/{product_id}/options`
 
@@ -4789,67 +3016,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `GET /catalog/products/{product_id}/options/{option_id}`
 
 Gets `Option` object by product ID and option id.
@@ -4946,67 +3112,6 @@ This operation does not require authentication
 ## updateOption
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/products/{product_id}/options/{option_id}`
 
@@ -5177,67 +3282,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/products/{product_id}/options/{option_id}`
 
 Deletes a Product's `Option`, based on the product_id and option_id.
@@ -5272,67 +3316,6 @@ This operation does not require authentication
 ## getModifiers
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/modifiers`
 
@@ -5445,67 +3428,6 @@ This operation does not require authentication
 ## createModifier
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/products/{product_id}/modifiers`
 
@@ -5701,67 +3623,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `GET /catalog/products/{product_id}/modifiers/{modifier_id}`
 
 Gets a `Modifier` by product_id and modifier_id.
@@ -5875,67 +3736,6 @@ This operation does not require authentication
 ## updateModifier
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/products/{product_id}/modifiers/{modifier_id}`
 
@@ -6135,67 +3935,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/products/{product_id}/modifiers/{modifier_id}`
 
 Deletes a Product's `Modifier` based on the product_id and modifier_id.
@@ -6230,67 +3969,6 @@ This operation does not require authentication
 ## createModifierImage
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "multipart/form-data",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image`
 
@@ -6368,67 +4046,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image`
 
 Deletes the image applied to show when the modifier value is selected
@@ -6465,67 +4082,6 @@ This operation does not require authentication
 ## getComplexRules
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/complex-rules`
 
@@ -6605,67 +4161,6 @@ This operation does not require authentication
 ## createComplexRule
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/products/{product_id}/complex-rules`
 
@@ -6795,67 +4290,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `GET /catalog/products/{product_id}/complex-rules/{complex_rule_id}`
 
 Gets a `ComplexRule` by product_id.
@@ -6936,67 +4370,6 @@ This operation does not require authentication
 ## updateComplexRule
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/products/{product_id}/complex-rules/{complex_rule_id}`
 
@@ -7132,67 +4505,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/products/{product_id}/complex-rules/{complex_rule_id}`
 
 Deletes a Product's `ComplexRule`, based on the `product_id` and `complex_rule_id`.
@@ -7227,67 +4539,6 @@ This operation does not require authentication
 ## getProductMetafieldsByProductId
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/metafields`
 
@@ -7344,8 +4595,8 @@ Status|Meaning|Description
       "resource_type": "category",
       "resource_id": 0,
       "id": 0,
-      "created_at": "2017-02-07T18:24:53Z",
-      "updated_at": "2017-02-07T18:24:53Z"
+      "created_at": "2017-02-07T19:44:56Z",
+      "updated_at": "2017-02-07T19:44:56Z"
     }
   ],
   "meta": {
@@ -7377,67 +4628,6 @@ This operation does not require authentication
 ## createProductMetafield
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/products/{product_id}/metafields`
 
@@ -7495,8 +4685,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -7532,67 +4722,6 @@ This operation does not require authentication
 ## getProductMetafieldByProductId
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/products/{product_id}/metafields/{metafield_id}`
 
@@ -7636,8 +4765,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -7657,67 +4786,6 @@ This operation does not require authentication
 ## updateProductMetafield
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/products/{product_id}/metafields/{metafield_id}`
 
@@ -7778,8 +4846,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -7799,67 +4867,6 @@ This operation does not require authentication
 ## deleteProductMetafieldById
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `DELETE /catalog/products/{product_id}/metafields/{metafield_id}`
 
@@ -7895,67 +4902,6 @@ This operation does not require authentication
 ## getCategories
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/categories`
 
@@ -8053,67 +4999,6 @@ This operation does not require authentication
 ## createCategory
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/categories`
 
@@ -8228,67 +5113,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/categories`
 
 Deletes a product or products from the BigCommerce Catalog.
@@ -8335,67 +5159,6 @@ This operation does not require authentication
 ## getCategoryById
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/categories/{category_id}`
 
@@ -8466,67 +5229,6 @@ This operation does not require authentication
 ## updateCategory
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/categories/{category_id}`
 
@@ -8655,67 +5357,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/categories/{category_id}`
 
 Deletes one or more `Category` objects from the BigCommerce catalog.
@@ -8746,67 +5387,6 @@ This operation does not require authentication
 ## getCategoryMetafieldsByCategoryId
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/categories/{category_id}/metafields`
 
@@ -8863,8 +5443,8 @@ Status|Meaning|Description
       "resource_type": "category",
       "resource_id": 0,
       "id": 0,
-      "created_at": "2017-02-07T18:24:53Z",
-      "updated_at": "2017-02-07T18:24:53Z"
+      "created_at": "2017-02-07T19:44:56Z",
+      "updated_at": "2017-02-07T19:44:56Z"
     }
   ],
   "meta": {
@@ -8896,67 +5476,6 @@ This operation does not require authentication
 ## createCategoryMetafield
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/categories/{category_id}/metafields`
 
@@ -9014,8 +5533,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -9051,67 +5570,6 @@ This operation does not require authentication
 ## getCategoryMetafieldByCategoryId
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/categories/{category_id}/metafields/{metafield_id}`
 
@@ -9155,8 +5613,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -9176,67 +5634,6 @@ This operation does not require authentication
 ## updateCategoryMetafield
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/categories/{category_id}/metafields/{metafield_id}`
 
@@ -9297,8 +5694,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -9318,67 +5715,6 @@ This operation does not require authentication
 ## deleteCategoryMetafieldById
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `DELETE /catalog/categories/{category_id}/metafields/{metafield_id}`
 
@@ -9414,67 +5750,6 @@ This operation does not require authentication
 ## createCategoryImage
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "multipart/form-data",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/categories/{category_id}/image`
 
@@ -9545,67 +5820,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/categories/{category_id}/image`
 
 Deletes a `Category` image from the BigCommerce Catalog.
@@ -9636,67 +5850,6 @@ This operation does not require authentication
 ## getCategoryTree
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/categories/tree`
 
@@ -9738,67 +5891,6 @@ This operation does not require authentication
 ## getBrands
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/brands`
 
@@ -9873,67 +5965,6 @@ This operation does not require authentication
 ## createBrand
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/brands`
 
@@ -10025,67 +6056,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/brands`
 
 Deletes one or more `Brand` objects from the BigCommerce Catalog.
@@ -10120,67 +6090,6 @@ This operation does not require authentication
 ## getBrandById
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/brands/{brand_id}`
 
@@ -10239,67 +6148,6 @@ This operation does not require authentication
 ## updateBrand
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/brands/{brand_id}`
 
@@ -10407,67 +6255,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/brands/{brand_id}`
 
 Deletes a `Brand` from the BigCommerce Catalog.
@@ -10498,67 +6285,6 @@ This operation does not require authentication
 ## getBrandMetafieldsByBrandId
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/brands/{brand_id}/metafields`
 
@@ -10615,8 +6341,8 @@ Status|Meaning|Description
       "resource_type": "category",
       "resource_id": 0,
       "id": 0,
-      "created_at": "2017-02-07T18:24:53Z",
-      "updated_at": "2017-02-07T18:24:53Z"
+      "created_at": "2017-02-07T19:44:56Z",
+      "updated_at": "2017-02-07T19:44:56Z"
     }
   ],
   "meta": {
@@ -10648,67 +6374,6 @@ This operation does not require authentication
 ## createBrandMetafield
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/brands/{brand_id}/metafields`
 
@@ -10766,8 +6431,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -10803,67 +6468,6 @@ This operation does not require authentication
 ## getBrandMetafieldByBrandId
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/brands/{brand_id}/metafields/{metafield_id}`
 
@@ -10907,8 +6511,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -10928,67 +6532,6 @@ This operation does not require authentication
 ## updateBrandMetafield
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /catalog/brands/{brand_id}/metafields/{metafield_id}`
 
@@ -11049,8 +6592,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-07T18:24:53Z",
-    "updated_at": "2017-02-07T18:24:53Z"
+    "created_at": "2017-02-07T19:44:56Z",
+    "updated_at": "2017-02-07T19:44:56Z"
   },
   "meta": {}
 }
@@ -11070,67 +6613,6 @@ This operation does not require authentication
 ## deleteBrandMetafieldById
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `DELETE /catalog/brands/{brand_id}/metafields/{metafield_id}`
 
@@ -11166,67 +6648,6 @@ This operation does not require authentication
 ## createBrandImage
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "multipart/form-data",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `POST /catalog/brands/{brand_id}/image`
 
@@ -11297,67 +6718,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /catalog/brands/{brand_id}/image`
 
 Deletes a `Brand` image from the BigCommerce Catalog.
@@ -11387,67 +6747,6 @@ This operation does not require authentication
 ## getVariants
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /catalog/variants`
 
@@ -11546,67 +6845,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 Returns a lightweight inventory summary from the BigCommerce Catalog.
 
 
@@ -11639,67 +6877,6 @@ This operation does not require authentication
 ## getSubscribers
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /customers/subscribers`
 
@@ -11794,67 +6971,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', { method: 'POST'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.post 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `POST /customers/subscribers`
 
 Creates a `Subscriber` object.
@@ -11943,67 +7059,6 @@ This operation does not require authentication
 
 > Code samples
 
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
-
 `DELETE /customers/subscribers`
 
 Deletes a Subscriber or Subscribers from BigCommerce Customers.
@@ -12058,67 +7113,6 @@ This operation does not require authentication
 ## getSubscriberById
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /customers/subscribers/{subscriber_id}`
 
@@ -12176,67 +7170,6 @@ This operation does not require authentication
 ## updateSubscriber
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', { method: 'PUT'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.put 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `PUT /customers/subscribers/{subscriber_id}`
 
@@ -12339,67 +7272,6 @@ This operation does not require authentication
 ## deleteSubscriberById
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', { method: 'DELETE'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.delete 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `DELETE /customers/subscribers/{subscriber_id}`
 

--- a/source/api/v3/openapi-catalog.html.md
+++ b/source/api/v3/openapi-catalog.html.md
@@ -2,13 +2,11 @@
 title: BigCommerce Catalog API v3.0.0b
 layout: "layout"
 language_tabs:
-  - shell: Shell
-  - http: HTTP
-  - html: JavaScript
-  - javascript: Node.JS
-  - python: Python
-  - ruby: Ruby
-  - java: Java
+  - shell
+  - python
+  - java
+  - ruby
+  - javascript
 toc_footers: []
 includes: []
 search: true
@@ -34,27 +32,9 @@ BigCommerce Catalog API Definition.
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -82,7 +62,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', headers=headers, params={
   # TODO
 })
 
@@ -272,54 +259,65 @@ Status|Meaning|Description
 {
   "data": [
     {
-      "is_price_hidden": true,
-      "view_count": 0,
-      "brand_id": 0,
-      "availability": "available",
-      "is_preorder_only": true,
-      "price": 0,
-      "sort_order": 0,
-      "meta_keywords": [
-        "string"
-      ],
-      "type": "physical",
-      "inventory_tracking": "none",
-      "depth": 0,
-      "is_featured": true,
-      "availability_description": "string",
-      "search_keywords": "string",
-      "tax_class_id": 0,
-      "order_quantity_maximum": 0,
-      "condition": "New",
       "name": "string",
-      "page_title": "string",
+      "type": "physical",
+      "sku": "string",
+      "description": "string",
+      "weight": 0,
+      "width": 0,
+      "depth": 0,
+      "height": 0,
+      "price": 0,
+      "cost_price": 0,
+      "retail_price": 0,
+      "sale_price": 0,
+      "tax_class_id": 0,
+      "product_tax_code": "string",
+      "categories": [
+        0
+      ],
+      "brand_id": 0,
+      "inventory_level": 0,
+      "inventory_warning_level": 0,
+      "inventory_tracking": "none",
+      "fixed_cost_shipping_price": 0,
       "is_free_shipping": true,
+      "is_visible": true,
+      "is_featured": true,
+      "related_products": [
+        0
+      ],
+      "warranty": "string",
+      "bin_picking_number": "string",
+      "layout_file": "string",
+      "upc": "string",
+      "search_keywords": "string",
+      "availability": "available",
+      "availability_description": "string",
+      "gift_wrapping_options_type": "any",
       "gift_wrapping_options_list": [
         0
       ],
+      "sort_order": 0,
+      "condition": "New",
+      "is_condition_shown": true,
+      "order_quantity_minimum": 0,
+      "order_quantity_maximum": 0,
+      "page_title": "string",
+      "meta_keywords": [
+        "string"
+      ],
+      "meta_description": "string",
+      "view_count": 0,
       "preorder_release_date": "string",
-      "sale_price": 0,
-      "height": 0,
-      "product_tax_code": "string",
-      "warranty": "string",
+      "preorder_message": "string",
+      "is_preorder_only": true,
+      "is_price_hidden": true,
+      "price_hidden_label": "string",
       "custom_url": {
         "url": "string",
         "is_customized": true
       },
-      "fixed_cost_shipping_price": 0,
-      "weight": 0,
-      "width": 0,
-      "retail_price": 0,
-      "categories": [
-        0
-      ],
-      "inventory_warning_level": 0,
-      "bin_picking_number": "string",
-      "layout_file": "string",
-      "gift_wrapping_options_type": "any",
-      "is_visible": true,
-      "inventory_level": 0,
-      "description": "string",
       "bulk_pricing_rules": [
         {
           "id": 0,
@@ -329,17 +327,6 @@ Status|Meaning|Description
           "amount": 0
         }
       ],
-      "order_quantity_minimum": 0,
-      "preorder_message": "string",
-      "meta_description": "string",
-      "cost_price": 0,
-      "upc": "string",
-      "price_hidden_label": "string",
-      "related_products": [
-        0
-      ],
-      "sku": "string",
-      "is_condition_shown": true,
       "id": 0,
       "calculated_price": 0,
       "custom_fields": [
@@ -427,27 +414,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -475,7 +444,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', headers=headers, params={
   # TODO
 })
 
@@ -518,54 +494,65 @@ A BigCommerce `Product` object.
 
 ````json
 {
-  "is_price_hidden": true,
-  "view_count": 0,
-  "brand_id": 0,
-  "availability": "available",
-  "is_preorder_only": true,
-  "price": 0,
-  "sort_order": 0,
-  "meta_keywords": [
-    "string"
-  ],
-  "type": "physical",
-  "inventory_tracking": "none",
-  "depth": 0,
-  "is_featured": true,
-  "availability_description": "string",
-  "search_keywords": "string",
-  "tax_class_id": 0,
-  "order_quantity_maximum": 0,
-  "condition": "New",
   "name": "string",
-  "page_title": "string",
+  "type": "physical",
+  "sku": "string",
+  "description": "string",
+  "weight": 0,
+  "width": 0,
+  "depth": 0,
+  "height": 0,
+  "price": 0,
+  "cost_price": 0,
+  "retail_price": 0,
+  "sale_price": 0,
+  "tax_class_id": 0,
+  "product_tax_code": "string",
+  "categories": [
+    0
+  ],
+  "brand_id": 0,
+  "inventory_level": 0,
+  "inventory_warning_level": 0,
+  "inventory_tracking": "none",
+  "fixed_cost_shipping_price": 0,
   "is_free_shipping": true,
+  "is_visible": true,
+  "is_featured": true,
+  "related_products": [
+    0
+  ],
+  "warranty": "string",
+  "bin_picking_number": "string",
+  "layout_file": "string",
+  "upc": "string",
+  "search_keywords": "string",
+  "availability": "available",
+  "availability_description": "string",
+  "gift_wrapping_options_type": "any",
   "gift_wrapping_options_list": [
     0
   ],
+  "sort_order": 0,
+  "condition": "New",
+  "is_condition_shown": true,
+  "order_quantity_minimum": 0,
+  "order_quantity_maximum": 0,
+  "page_title": "string",
+  "meta_keywords": [
+    "string"
+  ],
+  "meta_description": "string",
+  "view_count": 0,
   "preorder_release_date": "string",
-  "sale_price": 0,
-  "height": 0,
-  "product_tax_code": "string",
-  "warranty": "string",
+  "preorder_message": "string",
+  "is_preorder_only": true,
+  "is_price_hidden": true,
+  "price_hidden_label": "string",
   "custom_url": {
     "url": "string",
     "is_customized": true
   },
-  "fixed_cost_shipping_price": 0,
-  "weight": 0,
-  "width": 0,
-  "retail_price": 0,
-  "categories": [
-    0
-  ],
-  "inventory_warning_level": 0,
-  "bin_picking_number": "string",
-  "layout_file": "string",
-  "gift_wrapping_options_type": "any",
-  "is_visible": true,
-  "inventory_level": 0,
-  "description": "string",
   "bulk_pricing_rules": [
     {
       "id": 0,
@@ -575,17 +562,6 @@ A BigCommerce `Product` object.
       "amount": 0
     }
   ],
-  "order_quantity_minimum": 0,
-  "preorder_message": "string",
-  "meta_description": "string",
-  "cost_price": 0,
-  "upc": "string",
-  "price_hidden_label": "string",
-  "related_products": [
-    0
-  ],
-  "sku": "string",
-  "is_condition_shown": true,
   "custom_fields": [
     {
       "id": 1,
@@ -633,54 +609,65 @@ Status|Meaning|Description
 ````json
 {
   "data": {
-    "is_price_hidden": true,
-    "view_count": 0,
-    "brand_id": 0,
-    "availability": "available",
-    "is_preorder_only": true,
-    "price": 0,
-    "sort_order": 0,
-    "meta_keywords": [
-      "string"
-    ],
-    "type": "physical",
-    "inventory_tracking": "none",
-    "depth": 0,
-    "is_featured": true,
-    "availability_description": "string",
-    "search_keywords": "string",
-    "tax_class_id": 0,
-    "order_quantity_maximum": 0,
-    "condition": "New",
     "name": "string",
-    "page_title": "string",
+    "type": "physical",
+    "sku": "string",
+    "description": "string",
+    "weight": 0,
+    "width": 0,
+    "depth": 0,
+    "height": 0,
+    "price": 0,
+    "cost_price": 0,
+    "retail_price": 0,
+    "sale_price": 0,
+    "tax_class_id": 0,
+    "product_tax_code": "string",
+    "categories": [
+      0
+    ],
+    "brand_id": 0,
+    "inventory_level": 0,
+    "inventory_warning_level": 0,
+    "inventory_tracking": "none",
+    "fixed_cost_shipping_price": 0,
     "is_free_shipping": true,
+    "is_visible": true,
+    "is_featured": true,
+    "related_products": [
+      0
+    ],
+    "warranty": "string",
+    "bin_picking_number": "string",
+    "layout_file": "string",
+    "upc": "string",
+    "search_keywords": "string",
+    "availability": "available",
+    "availability_description": "string",
+    "gift_wrapping_options_type": "any",
     "gift_wrapping_options_list": [
       0
     ],
+    "sort_order": 0,
+    "condition": "New",
+    "is_condition_shown": true,
+    "order_quantity_minimum": 0,
+    "order_quantity_maximum": 0,
+    "page_title": "string",
+    "meta_keywords": [
+      "string"
+    ],
+    "meta_description": "string",
+    "view_count": 0,
     "preorder_release_date": "string",
-    "sale_price": 0,
-    "height": 0,
-    "product_tax_code": "string",
-    "warranty": "string",
+    "preorder_message": "string",
+    "is_preorder_only": true,
+    "is_price_hidden": true,
+    "price_hidden_label": "string",
     "custom_url": {
       "url": "string",
       "is_customized": true
     },
-    "fixed_cost_shipping_price": 0,
-    "weight": 0,
-    "width": 0,
-    "retail_price": 0,
-    "categories": [
-      0
-    ],
-    "inventory_warning_level": 0,
-    "bin_picking_number": "string",
-    "layout_file": "string",
-    "gift_wrapping_options_type": "any",
-    "is_visible": true,
-    "inventory_level": 0,
-    "description": "string",
     "bulk_pricing_rules": [
       {
         "id": 0,
@@ -690,17 +677,6 @@ Status|Meaning|Description
         "amount": 0
       }
     ],
-    "order_quantity_minimum": 0,
-    "preorder_message": "string",
-    "meta_description": "string",
-    "cost_price": 0,
-    "upc": "string",
-    "price_hidden_label": "string",
-    "related_products": [
-      0
-    ],
-    "sku": "string",
-    "is_condition_shown": true,
     "id": 0,
     "calculated_price": 0,
     "custom_fields": [
@@ -800,27 +776,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -848,7 +806,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products', headers=headers, params={
   # TODO
 })
 
@@ -959,27 +924,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1007,7 +954,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', headers=headers, params={
   # TODO
 })
 
@@ -1074,54 +1028,65 @@ Status|Meaning|Description
 ````json
 {
   "data": {
-    "is_price_hidden": true,
-    "view_count": 0,
-    "brand_id": 0,
-    "availability": "available",
-    "is_preorder_only": true,
-    "price": 0,
-    "sort_order": 0,
-    "meta_keywords": [
-      "string"
-    ],
-    "type": "physical",
-    "inventory_tracking": "none",
-    "depth": 0,
-    "is_featured": true,
-    "availability_description": "string",
-    "search_keywords": "string",
-    "tax_class_id": 0,
-    "order_quantity_maximum": 0,
-    "condition": "New",
     "name": "string",
-    "page_title": "string",
+    "type": "physical",
+    "sku": "string",
+    "description": "string",
+    "weight": 0,
+    "width": 0,
+    "depth": 0,
+    "height": 0,
+    "price": 0,
+    "cost_price": 0,
+    "retail_price": 0,
+    "sale_price": 0,
+    "tax_class_id": 0,
+    "product_tax_code": "string",
+    "categories": [
+      0
+    ],
+    "brand_id": 0,
+    "inventory_level": 0,
+    "inventory_warning_level": 0,
+    "inventory_tracking": "none",
+    "fixed_cost_shipping_price": 0,
     "is_free_shipping": true,
+    "is_visible": true,
+    "is_featured": true,
+    "related_products": [
+      0
+    ],
+    "warranty": "string",
+    "bin_picking_number": "string",
+    "layout_file": "string",
+    "upc": "string",
+    "search_keywords": "string",
+    "availability": "available",
+    "availability_description": "string",
+    "gift_wrapping_options_type": "any",
     "gift_wrapping_options_list": [
       0
     ],
+    "sort_order": 0,
+    "condition": "New",
+    "is_condition_shown": true,
+    "order_quantity_minimum": 0,
+    "order_quantity_maximum": 0,
+    "page_title": "string",
+    "meta_keywords": [
+      "string"
+    ],
+    "meta_description": "string",
+    "view_count": 0,
     "preorder_release_date": "string",
-    "sale_price": 0,
-    "height": 0,
-    "product_tax_code": "string",
-    "warranty": "string",
+    "preorder_message": "string",
+    "is_preorder_only": true,
+    "is_price_hidden": true,
+    "price_hidden_label": "string",
     "custom_url": {
       "url": "string",
       "is_customized": true
     },
-    "fixed_cost_shipping_price": 0,
-    "weight": 0,
-    "width": 0,
-    "retail_price": 0,
-    "categories": [
-      0
-    ],
-    "inventory_warning_level": 0,
-    "bin_picking_number": "string",
-    "layout_file": "string",
-    "gift_wrapping_options_type": "any",
-    "is_visible": true,
-    "inventory_level": 0,
-    "description": "string",
     "bulk_pricing_rules": [
       {
         "id": 0,
@@ -1131,17 +1096,6 @@ Status|Meaning|Description
         "amount": 0
       }
     ],
-    "order_quantity_minimum": 0,
-    "preorder_message": "string",
-    "meta_description": "string",
-    "cost_price": 0,
-    "upc": "string",
-    "price_hidden_label": "string",
-    "related_products": [
-      0
-    ],
-    "sku": "string",
-    "is_condition_shown": true,
     "id": 0,
     "calculated_price": 0,
     "custom_fields": [
@@ -1225,27 +1179,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1273,7 +1209,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', headers=headers, params={
   # TODO
 })
 
@@ -1320,54 +1263,65 @@ A BigCommerce `Product` object.
 
 ````json
 {
-  "is_price_hidden": true,
-  "view_count": 0,
-  "brand_id": 0,
-  "availability": "available",
-  "is_preorder_only": true,
-  "price": 0,
-  "sort_order": 0,
-  "meta_keywords": [
-    "string"
-  ],
-  "type": "physical",
-  "inventory_tracking": "none",
-  "depth": 0,
-  "is_featured": true,
-  "availability_description": "string",
-  "search_keywords": "string",
-  "tax_class_id": 0,
-  "order_quantity_maximum": 0,
-  "condition": "New",
   "name": "string",
-  "page_title": "string",
+  "type": "physical",
+  "sku": "string",
+  "description": "string",
+  "weight": 0,
+  "width": 0,
+  "depth": 0,
+  "height": 0,
+  "price": 0,
+  "cost_price": 0,
+  "retail_price": 0,
+  "sale_price": 0,
+  "tax_class_id": 0,
+  "product_tax_code": "string",
+  "categories": [
+    0
+  ],
+  "brand_id": 0,
+  "inventory_level": 0,
+  "inventory_warning_level": 0,
+  "inventory_tracking": "none",
+  "fixed_cost_shipping_price": 0,
   "is_free_shipping": true,
+  "is_visible": true,
+  "is_featured": true,
+  "related_products": [
+    0
+  ],
+  "warranty": "string",
+  "bin_picking_number": "string",
+  "layout_file": "string",
+  "upc": "string",
+  "search_keywords": "string",
+  "availability": "available",
+  "availability_description": "string",
+  "gift_wrapping_options_type": "any",
   "gift_wrapping_options_list": [
     0
   ],
+  "sort_order": 0,
+  "condition": "New",
+  "is_condition_shown": true,
+  "order_quantity_minimum": 0,
+  "order_quantity_maximum": 0,
+  "page_title": "string",
+  "meta_keywords": [
+    "string"
+  ],
+  "meta_description": "string",
+  "view_count": 0,
   "preorder_release_date": "string",
-  "sale_price": 0,
-  "height": 0,
-  "product_tax_code": "string",
-  "warranty": "string",
+  "preorder_message": "string",
+  "is_preorder_only": true,
+  "is_price_hidden": true,
+  "price_hidden_label": "string",
   "custom_url": {
     "url": "string",
     "is_customized": true
   },
-  "fixed_cost_shipping_price": 0,
-  "weight": 0,
-  "width": 0,
-  "retail_price": 0,
-  "categories": [
-    0
-  ],
-  "inventory_warning_level": 0,
-  "bin_picking_number": "string",
-  "layout_file": "string",
-  "gift_wrapping_options_type": "any",
-  "is_visible": true,
-  "inventory_level": 0,
-  "description": "string",
   "bulk_pricing_rules": [
     {
       "id": 0,
@@ -1377,17 +1331,6 @@ A BigCommerce `Product` object.
       "amount": 0
     }
   ],
-  "order_quantity_minimum": 0,
-  "preorder_message": "string",
-  "meta_description": "string",
-  "cost_price": 0,
-  "upc": "string",
-  "price_hidden_label": "string",
-  "related_products": [
-    0
-  ],
-  "sku": "string",
-  "is_condition_shown": true,
   "id": 0,
   "custom_fields": [
     {
@@ -1432,54 +1375,65 @@ Status|Meaning|Description
 ````json
 {
   "data": {
-    "is_price_hidden": true,
-    "view_count": 0,
-    "brand_id": 0,
-    "availability": "available",
-    "is_preorder_only": true,
-    "price": 0,
-    "sort_order": 0,
-    "meta_keywords": [
-      "string"
-    ],
-    "type": "physical",
-    "inventory_tracking": "none",
-    "depth": 0,
-    "is_featured": true,
-    "availability_description": "string",
-    "search_keywords": "string",
-    "tax_class_id": 0,
-    "order_quantity_maximum": 0,
-    "condition": "New",
     "name": "string",
-    "page_title": "string",
+    "type": "physical",
+    "sku": "string",
+    "description": "string",
+    "weight": 0,
+    "width": 0,
+    "depth": 0,
+    "height": 0,
+    "price": 0,
+    "cost_price": 0,
+    "retail_price": 0,
+    "sale_price": 0,
+    "tax_class_id": 0,
+    "product_tax_code": "string",
+    "categories": [
+      0
+    ],
+    "brand_id": 0,
+    "inventory_level": 0,
+    "inventory_warning_level": 0,
+    "inventory_tracking": "none",
+    "fixed_cost_shipping_price": 0,
     "is_free_shipping": true,
+    "is_visible": true,
+    "is_featured": true,
+    "related_products": [
+      0
+    ],
+    "warranty": "string",
+    "bin_picking_number": "string",
+    "layout_file": "string",
+    "upc": "string",
+    "search_keywords": "string",
+    "availability": "available",
+    "availability_description": "string",
+    "gift_wrapping_options_type": "any",
     "gift_wrapping_options_list": [
       0
     ],
+    "sort_order": 0,
+    "condition": "New",
+    "is_condition_shown": true,
+    "order_quantity_minimum": 0,
+    "order_quantity_maximum": 0,
+    "page_title": "string",
+    "meta_keywords": [
+      "string"
+    ],
+    "meta_description": "string",
+    "view_count": 0,
     "preorder_release_date": "string",
-    "sale_price": 0,
-    "height": 0,
-    "product_tax_code": "string",
-    "warranty": "string",
+    "preorder_message": "string",
+    "is_preorder_only": true,
+    "is_price_hidden": true,
+    "price_hidden_label": "string",
     "custom_url": {
       "url": "string",
       "is_customized": true
     },
-    "fixed_cost_shipping_price": 0,
-    "weight": 0,
-    "width": 0,
-    "retail_price": 0,
-    "categories": [
-      0
-    ],
-    "inventory_warning_level": 0,
-    "bin_picking_number": "string",
-    "layout_file": "string",
-    "gift_wrapping_options_type": "any",
-    "is_visible": true,
-    "inventory_level": 0,
-    "description": "string",
     "bulk_pricing_rules": [
       {
         "id": 0,
@@ -1489,17 +1443,6 @@ Status|Meaning|Description
         "amount": 0
       }
     ],
-    "order_quantity_minimum": 0,
-    "preorder_message": "string",
-    "meta_description": "string",
-    "cost_price": 0,
-    "upc": "string",
-    "price_hidden_label": "string",
-    "related_products": [
-      0
-    ],
-    "sku": "string",
-    "is_condition_shown": true,
     "id": 0,
     "calculated_price": 0,
     "custom_fields": [
@@ -1607,27 +1550,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1655,7 +1580,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}', headers=headers, params={
   # TODO
 })
 
@@ -1710,27 +1642,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1758,7 +1672,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', headers=headers, params={
   # TODO
 })
 
@@ -1857,27 +1778,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -1905,7 +1808,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images', headers=headers, params={
   # TODO
 })
 
@@ -2004,27 +1914,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -2052,7 +1944,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', headers=headers, params={
   # TODO
 })
 
@@ -2140,27 +2039,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -2188,7 +2069,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', headers=headers, params={
   # TODO
 })
 
@@ -2289,27 +2177,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -2337,7 +2207,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/images/{image_id}', headers=headers, params={
   # TODO
 })
 
@@ -2396,27 +2273,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -2444,7 +2303,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', headers=headers, params={
   # TODO
 })
 
@@ -2527,27 +2393,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -2575,7 +2423,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos', headers=headers, params={
   # TODO
 })
 
@@ -2670,27 +2525,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -2718,7 +2555,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', headers=headers, params={
   # TODO
 })
 
@@ -2802,27 +2646,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -2850,7 +2676,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', headers=headers, params={
   # TODO
 })
 
@@ -2947,27 +2780,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -2995,7 +2810,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/videos/{video_id}', headers=headers, params={
   # TODO
 })
 
@@ -3054,27 +2876,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -3102,7 +2906,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', headers=headers, params={
   # TODO
 })
 
@@ -3219,27 +3030,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -3267,7 +3060,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants', headers=headers, params={
   # TODO
 })
 
@@ -3390,27 +3190,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -3438,7 +3220,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', headers=headers, params={
   # TODO
 })
 
@@ -3537,27 +3326,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -3585,7 +3356,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', headers=headers, params={
   # TODO
 })
 
@@ -3705,27 +3483,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -3753,7 +3513,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}', headers=headers, params={
   # TODO
 })
 
@@ -3812,27 +3579,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -3860,7 +3609,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', headers=headers, params={
   # TODO
 })
 
@@ -3942,8 +3698,8 @@ Status|Meaning|Description
       "resource_type": "category",
       "resource_id": 0,
       "id": 0,
-      "created_at": "2017-02-06T23:34:51Z",
-      "updated_at": "2017-02-06T23:34:51Z"
+      "created_at": "2017-02-07T18:24:53Z",
+      "updated_at": "2017-02-07T18:24:53Z"
     }
   ],
   "meta": {
@@ -3977,27 +3733,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -4025,7 +3763,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields', headers=headers, params={
   # TODO
 })
 
@@ -4108,8 +3853,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -4147,27 +3892,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -4195,7 +3922,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -4264,8 +3998,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -4287,27 +4021,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -4335,7 +4051,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -4421,8 +4144,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -4444,27 +4167,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -4492,7 +4197,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -4555,27 +4267,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: multipart/form-data
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -4603,7 +4297,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image', params={
+headers = {
+	'Content-Type': "multipart/form-data",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/variants/{variant_id}/image', headers=headers, params={
   # TODO
 })
 
@@ -4697,27 +4398,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -4745,7 +4428,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', headers=headers, params={
   # TODO
 })
 
@@ -4808,8 +4498,8 @@ Status|Meaning|Description
         "checkbox_label": "string",
         "date_limited": true,
         "date_limit_mode": "earliest",
-        "date_earliest_value": "2017-02-06",
-        "date_latest_value": "2017-02-06",
+        "date_earliest_value": "2017-02-07",
+        "date_latest_value": "2017-02-07",
         "file_types_mode": "specific",
         "file_types_supported": [
           "string"
@@ -4875,27 +4565,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -4923,7 +4595,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options', headers=headers, params={
   # TODO
 })
 
@@ -4979,8 +4658,8 @@ An `Option` object.
     "checkbox_label": "string",
     "date_limited": true,
     "date_limit_mode": "earliest",
-    "date_earliest_value": "2017-02-06",
-    "date_latest_value": "2017-02-06",
+    "date_earliest_value": "2017-02-07",
+    "date_latest_value": "2017-02-07",
     "file_types_mode": "specific",
     "file_types_supported": [
       "string"
@@ -5040,8 +4719,8 @@ Status|Meaning|Description
       "checkbox_label": "string",
       "date_limited": true,
       "date_limit_mode": "earliest",
-      "date_earliest_value": "2017-02-06",
-      "date_latest_value": "2017-02-06",
+      "date_earliest_value": "2017-02-07",
+      "date_latest_value": "2017-02-07",
       "file_types_mode": "specific",
       "file_types_supported": [
         "string"
@@ -5111,27 +4790,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -5159,7 +4820,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', headers=headers, params={
   # TODO
 })
 
@@ -5225,8 +4893,8 @@ Status|Meaning|Description
       "checkbox_label": "string",
       "date_limited": true,
       "date_limit_mode": "earliest",
-      "date_earliest_value": "2017-02-06",
-      "date_latest_value": "2017-02-06",
+      "date_earliest_value": "2017-02-07",
+      "date_latest_value": "2017-02-07",
       "file_types_mode": "specific",
       "file_types_supported": [
         "string"
@@ -5280,27 +4948,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -5328,7 +4978,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', headers=headers, params={
   # TODO
 })
 
@@ -5389,8 +5046,8 @@ A BigCommerce `Option` object.
     "checkbox_label": "string",
     "date_limited": true,
     "date_limit_mode": "earliest",
-    "date_earliest_value": "2017-02-06",
-    "date_latest_value": "2017-02-06",
+    "date_earliest_value": "2017-02-07",
+    "date_latest_value": "2017-02-07",
     "file_types_mode": "specific",
     "file_types_supported": [
       "string"
@@ -5450,8 +5107,8 @@ Status|Meaning|Description
       "checkbox_label": "string",
       "date_limited": true,
       "date_limit_mode": "earliest",
-      "date_earliest_value": "2017-02-06",
-      "date_latest_value": "2017-02-06",
+      "date_earliest_value": "2017-02-07",
+      "date_latest_value": "2017-02-07",
       "file_types_mode": "specific",
       "file_types_supported": [
         "string"
@@ -5521,27 +5178,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -5569,7 +5208,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/options/{option_id}', headers=headers, params={
   # TODO
 })
 
@@ -5628,27 +5274,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -5676,7 +5304,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', headers=headers, params={
   # TODO
 })
 
@@ -5735,8 +5370,8 @@ Status|Meaning|Description
         "checkbox_label": "string",
         "date_limited": true,
         "date_limit_mode": "earliest",
-        "date_earliest_value": "2017-02-06",
-        "date_latest_value": "2017-02-06",
+        "date_earliest_value": "2017-02-07",
+        "date_latest_value": "2017-02-07",
         "file_types_mode": "specific",
         "file_types_supported": [
           "string"
@@ -5812,27 +5447,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -5860,7 +5477,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers', headers=headers, params={
   # TODO
 })
 
@@ -5914,8 +5538,8 @@ A `Modifier` object.
     "checkbox_label": "string",
     "date_limited": true,
     "date_limit_mode": "earliest",
-    "date_earliest_value": "2017-02-06",
-    "date_latest_value": "2017-02-06",
+    "date_earliest_value": "2017-02-07",
+    "date_latest_value": "2017-02-07",
     "file_types_mode": "specific",
     "file_types_supported": [
       "string"
@@ -5989,8 +5613,8 @@ Status|Meaning|Description
       "checkbox_label": "string",
       "date_limited": true,
       "date_limit_mode": "earliest",
-      "date_earliest_value": "2017-02-06",
-      "date_latest_value": "2017-02-06",
+      "date_earliest_value": "2017-02-07",
+      "date_latest_value": "2017-02-07",
       "file_types_mode": "specific",
       "file_types_supported": [
         "string"
@@ -6078,27 +5702,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -6126,7 +5732,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', headers=headers, params={
   # TODO
 })
 
@@ -6191,8 +5804,8 @@ Status|Meaning|Description
       "checkbox_label": "string",
       "date_limited": true,
       "date_limit_mode": "earliest",
-      "date_earliest_value": "2017-02-06",
-      "date_latest_value": "2017-02-06",
+      "date_earliest_value": "2017-02-07",
+      "date_latest_value": "2017-02-07",
       "file_types_mode": "specific",
       "file_types_supported": [
         "string"
@@ -6264,27 +5877,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -6312,7 +5907,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', headers=headers, params={
   # TODO
 })
 
@@ -6371,8 +5973,8 @@ A BigCommerce `Modifier` object.
     "checkbox_label": "string",
     "date_limited": true,
     "date_limit_mode": "earliest",
-    "date_earliest_value": "2017-02-06",
-    "date_latest_value": "2017-02-06",
+    "date_earliest_value": "2017-02-07",
+    "date_latest_value": "2017-02-07",
     "file_types_mode": "specific",
     "file_types_supported": [
       "string"
@@ -6445,8 +6047,8 @@ Status|Meaning|Description
       "checkbox_label": "string",
       "date_limited": true,
       "date_limit_mode": "earliest",
-      "date_earliest_value": "2017-02-06",
-      "date_latest_value": "2017-02-06",
+      "date_earliest_value": "2017-02-07",
+      "date_latest_value": "2017-02-07",
       "file_types_mode": "specific",
       "file_types_supported": [
         "string"
@@ -6534,27 +6136,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -6582,7 +6166,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}', headers=headers, params={
   # TODO
 })
 
@@ -6641,27 +6232,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: multipart/form-data
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -6689,7 +6262,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', params={
+headers = {
+	'Content-Type': "multipart/form-data",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', headers=headers, params={
   # TODO
 })
 
@@ -6789,27 +6369,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -6837,7 +6399,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/modifiers/{modifier_id}/values/{value_id}/image', headers=headers, params={
   # TODO
 })
 
@@ -6898,27 +6467,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -6946,7 +6497,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', headers=headers, params={
   # TODO
 })
 
@@ -7049,27 +6607,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -7097,7 +6637,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules', headers=headers, params={
   # TODO
 })
 
@@ -7249,27 +6796,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -7297,7 +6826,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', headers=headers, params={
   # TODO
 })
 
@@ -7402,27 +6938,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -7450,7 +6968,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', headers=headers, params={
   # TODO
 })
 
@@ -7608,27 +7133,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -7656,7 +7163,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/complex-rules/{complex_rule_id}', headers=headers, params={
   # TODO
 })
 
@@ -7715,27 +7229,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -7763,7 +7259,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', headers=headers, params={
   # TODO
 })
 
@@ -7841,8 +7344,8 @@ Status|Meaning|Description
       "resource_type": "category",
       "resource_id": 0,
       "id": 0,
-      "created_at": "2017-02-06T23:34:51Z",
-      "updated_at": "2017-02-06T23:34:51Z"
+      "created_at": "2017-02-07T18:24:53Z",
+      "updated_at": "2017-02-07T18:24:53Z"
     }
   ],
   "meta": {
@@ -7876,27 +7379,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -7924,7 +7409,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields', headers=headers, params={
   # TODO
 })
 
@@ -8003,8 +7495,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -8042,27 +7534,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -8090,7 +7564,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -8155,8 +7636,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -8178,27 +7659,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -8226,7 +7689,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -8308,8 +7778,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -8331,27 +7801,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -8379,7 +7831,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/products/{product_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -8438,27 +7897,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -8486,7 +7927,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', headers=headers, params={
   # TODO
 })
 
@@ -8607,27 +8055,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -8655,7 +8085,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', headers=headers, params={
   # TODO
 })
 
@@ -8792,27 +8229,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -8840,7 +8259,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories', headers=headers, params={
   # TODO
 })
 
@@ -8911,27 +8337,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -8959,7 +8367,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', headers=headers, params={
   # TODO
 })
 
@@ -9053,27 +8468,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -9101,7 +8498,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', headers=headers, params={
   # TODO
 })
 
@@ -9252,27 +8656,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -9300,7 +8686,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}', headers=headers, params={
   # TODO
 })
 
@@ -9355,27 +8748,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -9403,7 +8778,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', headers=headers, params={
   # TODO
 })
 
@@ -9481,8 +8863,8 @@ Status|Meaning|Description
       "resource_type": "category",
       "resource_id": 0,
       "id": 0,
-      "created_at": "2017-02-06T23:34:51Z",
-      "updated_at": "2017-02-06T23:34:51Z"
+      "created_at": "2017-02-07T18:24:53Z",
+      "updated_at": "2017-02-07T18:24:53Z"
     }
   ],
   "meta": {
@@ -9516,27 +8898,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -9564,7 +8928,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields', headers=headers, params={
   # TODO
 })
 
@@ -9643,8 +9014,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -9682,27 +9053,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -9730,7 +9083,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -9795,8 +9155,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -9818,27 +9178,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -9866,7 +9208,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -9948,8 +9297,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -9971,27 +9320,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -10019,7 +9350,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -10078,27 +9416,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: multipart/form-data
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -10126,7 +9446,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', params={
+headers = {
+	'Content-Type': "multipart/form-data",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', headers=headers, params={
   # TODO
 })
 
@@ -10219,27 +9546,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -10267,7 +9576,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/{category_id}/image', headers=headers, params={
   # TODO
 })
 
@@ -10322,27 +9638,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -10370,7 +9668,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/categories/tree', headers=headers, params={
   # TODO
 })
 
@@ -10435,27 +9740,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -10483,7 +9770,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', headers=headers, params={
   # TODO
 })
 
@@ -10581,27 +9875,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -10629,7 +9905,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', headers=headers, params={
   # TODO
 })
 
@@ -10743,27 +10026,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -10791,7 +10056,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands', headers=headers, params={
   # TODO
 })
 
@@ -10850,27 +10122,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -10898,7 +10152,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', headers=headers, params={
   # TODO
 })
 
@@ -10980,27 +10241,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -11028,7 +10271,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', headers=headers, params={
   # TODO
 })
 
@@ -11158,27 +10408,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -11206,7 +10438,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}', headers=headers, params={
   # TODO
 })
 
@@ -11261,27 +10500,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -11309,7 +10530,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', headers=headers, params={
   # TODO
 })
 
@@ -11387,8 +10615,8 @@ Status|Meaning|Description
       "resource_type": "category",
       "resource_id": 0,
       "id": 0,
-      "created_at": "2017-02-06T23:34:51Z",
-      "updated_at": "2017-02-06T23:34:51Z"
+      "created_at": "2017-02-07T18:24:53Z",
+      "updated_at": "2017-02-07T18:24:53Z"
     }
   ],
   "meta": {
@@ -11422,27 +10650,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -11470,7 +10680,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields', headers=headers, params={
   # TODO
 })
 
@@ -11549,8 +10766,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -11588,27 +10805,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -11636,7 +10835,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -11701,8 +10907,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -11724,27 +10930,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -11772,7 +10960,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -11854,8 +11049,8 @@ Status|Meaning|Description
     "resource_type": "category",
     "resource_id": 0,
     "id": 0,
-    "created_at": "2017-02-06T23:34:51Z",
-    "updated_at": "2017-02-06T23:34:51Z"
+    "created_at": "2017-02-07T18:24:53Z",
+    "updated_at": "2017-02-07T18:24:53Z"
   },
   "meta": {}
 }
@@ -11877,27 +11072,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -11925,7 +11102,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/metafields/{metafield_id}', headers=headers, params={
   # TODO
 })
 
@@ -11984,27 +11168,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: multipart/form-data
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -12032,7 +11198,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', params={
+headers = {
+	'Content-Type': "multipart/form-data",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', headers=headers, params={
   # TODO
 })
 
@@ -12125,27 +11298,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -12173,7 +11328,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/brands/{brand_id}/image', headers=headers, params={
   # TODO
 })
 
@@ -12227,27 +11389,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -12275,7 +11419,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/variants', headers=headers, params={
   # TODO
 })
 
@@ -12396,27 +11547,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -12444,7 +11577,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/catalog/summary', headers=headers, params={
   # TODO
 })
 
@@ -12501,27 +11641,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -12549,7 +11671,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', headers=headers, params={
   # TODO
 })
 
@@ -12666,27 +11795,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X post https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers
-````
-
-````http
-POST https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers',
-    method: 'post',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -12714,7 +11825,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.post('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', headers=headers, params={
   # TODO
 })
 
@@ -12826,27 +11944,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -12874,7 +11974,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers', headers=headers, params={
   # TODO
 })
 
@@ -12953,27 +12060,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -13001,7 +12090,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', headers=headers, params={
   # TODO
 })
 
@@ -13082,27 +12178,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X put https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}
-````
-
-````http
-PUT https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}',
-    method: 'put',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -13130,7 +12208,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.put('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', headers=headers, params={
   # TODO
 })
 
@@ -13256,27 +12341,9 @@ This operation does not require authentication
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X delete https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}
-````
-
-````http
-DELETE https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id} HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}',
-    method: 'delete',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -13304,7 +12371,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.delete('https://api.bigcommerce.com/stores/{{store_id}}/v3/customers/subscribers/{subscriber_id}', headers=headers, params={
   # TODO
 })
 

--- a/source/api/v3/openapi-orders.html.md
+++ b/source/api/v3/openapi-orders.html.md
@@ -2,13 +2,11 @@
 title: BigCommerce Orders API v3.0.0
 layout: "layout"
 language_tabs:
-  - shell: Shell
-  - http: HTTP
-  - html: JavaScript
-  - javascript: Node.JS
-  - python: Python
-  - ruby: Ruby
-  - java: Java
+  - shell
+  - python
+  - java
+  - ruby
+  - javascript
 toc_footers: []
 includes: []
 search: true
@@ -34,27 +32,9 @@ BigCommerce Orders API Definition.
 > Code samples
 
 ````shell
+
 # You can also use wget
 curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions
-````
-
-````http
-GET https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions HTTP/1.1
-Host: api.bigcommerce.com
-Content-Type: application/json
-Accept: application/json
-````
-
-````html
-<script>
-  $.ajax({
-    url: 'https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions',
-    method: 'get',
-    success: function(data) {
-      console.log(JSON.stringify(data));
-    }
-  })
-</script>
 ````
 
 ````javascript
@@ -82,7 +62,14 @@ p JSON.parse(result)
 ````python
 import requests
 
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions', params={
+headers = {
+	'Content-Type': "application/json",
+	'Accept': "application/json",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions', headers=headers, params={
   # TODO
 })
 

--- a/source/api/v3/openapi-orders.html.md
+++ b/source/api/v3/openapi-orders.html.md
@@ -1,12 +1,8 @@
 ---
 title: BigCommerce Orders API v3.0.0
-layout: "layout"
+layout: "apitwocolumn"
 language_tabs:
-  - shell
-  - python
-  - java
-  - ruby
-  - javascript
+  - ''
 toc_footers: []
 includes: []
 search: true
@@ -30,67 +26,6 @@ BigCommerce Orders API Definition.
 ## getTransactions
 
 > Code samples
-
-````shell
-
-# You can also use wget
-curl -X get https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions
-````
-
-````javascript
-const request = require('node-fetch');
-fetch('https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions', { method: 'GET'})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-````
-
-````ruby
-require 'rest-client'
-require 'json'
-
-result = RestClient.get 'https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions', params:
-  {
-    # TODO
-  }
-
-p JSON.parse(result)
-````
-
-````python
-import requests
-
-headers = {
-	'Content-Type': "application/json",
-	'Accept': "application/json",
-	'X-Auth-Client': "SampleClientCode",
-	'X-Auth-Token': "8675309"
-}
-
-r = requests.get('https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions', headers=headers, params={
-  # TODO
-})
-
-print r.json()
-````
-
-````java
-URL obj = new URL("https://api.bigcommerce.com/stores/{{store_id}}/v3/orders/{order_id}/transactions");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-````
 
 `GET /orders/{order_id}/transactions`
 

--- a/swagger2md.js
+++ b/swagger2md.js
@@ -79,9 +79,9 @@ var endPath = "source/api/v3";
 var options = {}; // defaults shown
 options.codeSamples = true;
 options.yaml = true;
-//options.language_tabs = [];
+options.language_tabs = ['shell', 'python', 'java', 'ruby', 'javascript'];
 //options.loadedFrom = sourceUrl;
-//options.user_templates = './user_templates';
+options.user_templates = './user_templates';
 options.theme = 'darkula';
 
 // Delete all existing .generated.md files

--- a/swagger2md.js
+++ b/swagger2md.js
@@ -60,7 +60,7 @@ function generateMdFromSwagger(startPath, endPath){
             var generated = converter.convert(swagger,options);
 
             // Warning: hacky bullshit
-            generated = generated.replace('language_tabs:', 'layout: "layout"\nlanguage_tabs:');
+            generated = generated.replace('language_tabs:', 'layout: "apitwocolumn"\nlanguage_tabs:');
             // end hacky bullshit
             
             fs.writeFileSync(newFilename, generated, 'utf8')
@@ -79,7 +79,7 @@ var endPath = "source/api/v3";
 var options = {}; // defaults shown
 options.codeSamples = true;
 options.yaml = true;
-options.language_tabs = ['shell', 'python', 'java', 'ruby', 'javascript'];
+options.language_tabs = [''];
 //options.loadedFrom = sourceUrl;
 options.user_templates = './user_templates';
 options.theme = 'darkula';

--- a/user_templates/code_http.dot
+++ b/user_templates/code_http.dot
@@ -1,0 +1,4 @@
+{{=data.methodUpper}} {{=data.url}} HTTP/1.1
+Host: {{=data.host}}
+{{?data.consumes.length}}Content-Type: {{=data.consumes[0]}}{{?}}
+{{?data.produces.length}}Accept: {{=data.produces[0]}}{{?}}

--- a/user_templates/code_java.dot
+++ b/user_templates/code_java.dot
@@ -1,0 +1,13 @@
+URL obj = new URL("{{=data.url}}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("{{=data.methodUpper}}");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());

--- a/user_templates/code_javascript.dot
+++ b/user_templates/code_javascript.dot
@@ -1,0 +1,7 @@
+const request = require('node-fetch');
+fetch('{{=data.url}}', { method: '{{=data.methodUpper}}'})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});

--- a/user_templates/code_python.dot
+++ b/user_templates/code_python.dot
@@ -1,0 +1,14 @@
+import requests
+
+headers = {
+	'{{?data.consumes.length}}Content-Type': "{{=data.consumes[0]}}{{?}}",
+	'{{?data.produces.length}}Accept': "{{=data.produces[0]}}{{?}}",
+	'X-Auth-Client': "SampleClientCode",
+	'X-Auth-Token': "8675309"
+}
+
+r = requests.{{=data.method}}('{{=data.url}}', headers=headers, params={
+  # TODO
+})
+
+print r.json()

--- a/user_templates/code_ruby.dot
+++ b/user_templates/code_ruby.dot
@@ -1,0 +1,9 @@
+require 'rest-client'
+require 'json'
+
+result = RestClient.{{=data.method}} '{{=data.url}}', params:
+  {
+    # TODO
+  }
+
+p JSON.parse(result)

--- a/user_templates/code_shell.dot
+++ b/user_templates/code_shell.dot
@@ -1,0 +1,3 @@
+
+# You can also use wget
+curl -X {{=data.method}} {{=data.url}}


### PR DESCRIPTION
#### What?

Updated python template to a WIP state with headers

Changed swagger2md.js to:
- remove code sample generation until this can be refined
- change layout file until code samples need to be used
- made a change so it makes use of our templates instead of stock templates included with repo

Regenerated the files based off of these changes. 

#### How To Test

Run `node swagger2md.js` and verify no code samples are left

Run `bundle exec middleman rake` and view localhost:4567/api/v3/openapi-catalog.html to verify layout is correctly utilized

