### PR TITLE
DEV-23: Altered toc library to eliminate white space created by anchor divs

### DIFF
--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -12,8 +12,6 @@
 
   var makeToc = function() {
     global.toc = $("#toc").tocify({
-      /* selectors: 'h1, h2, h3, h4, h5, h6, h7', */
-      // ^ Swapped 8/4/16: Try limiting left-nav depth to 3 levels \/:
       selectors: 'h1, h2, h3',
       extendPage: false,
       theme: 'none',
@@ -22,9 +20,6 @@
       hideEffectSpeed: 180,
       ignoreSelector: '.toc-ignore',
       highlightOffset: 60,
-      /* Swapped on 6/24/16 – This clears left nav's link "upward" targets from below
-         the top nav, when using Nate's .erb JavaScript to make top nav intermittent: */
-      /* scrollTo: 85, */
       scrollTo: -1,
       scrollHistory: true,
       hashGenerator: function (text, element) {
@@ -42,8 +37,8 @@
     $(".tocify-item").click(closeToc);
   };
 
-  // Hack to make already open sections to start opened,
-  // instead of displaying an ugly animation
+  /* Hack to make already open sections to start opened,
+  instead of displaying an ugly animation */
   function animate() {
     setTimeout(function() {
       toc.setOption('showEffectSpeed', 180);

--- a/source/javascripts/lib/_jquery.tocify.js
+++ b/source/javascripts/lib/_jquery.tocify.js
@@ -411,7 +411,9 @@
                 // Sets a name attribute on the anchor tag to the text of the currently traversed HTML element (also making sure that all whitespace is replaced with an underscore)
                 "name": hashValue,
 
-                "data-unique": hashValue
+                "data-unique": hashValue,
+
+                "class": "anchor-text"
 
             }));
 

--- a/source/stylesheets/_custom.scss
+++ b/source/stylesheets/_custom.scss
@@ -367,3 +367,7 @@ li a, .tocify-wrapper {
 .mc-header {
   color: $bc-blue;
 }
+
+.anchor-text {
+  display: none;
+}


### PR DESCRIPTION
#### What?

Altered _tocify.jquery.js so that divs that create an anchor also add a class. This class is used to style the `divs` with `display:none` so that it doesn't negatively impact page layout. 

#### How To Test

- Verify anchors are still working from TOC
- On page complete, TOC shouldn't open unless an anchor was present in the URL
- No odd white space between middle column content

#### Tickets / Documentation

- [DEV-23](http://example.com)

#### Screenshots (if appropriate)

<img width="1440" alt="screen shot 2017-02-08 at 2 56 42 pm" src="https://cloud.githubusercontent.com/assets/9373485/22757099/1dafa3fe-ee0f-11e6-8034-4d6c8dd7a44a.png">

**Previously** (ignore ugly wireframe lines): 
<img width="1440" alt="screen shot 2017-02-08 at 2 18 19 pm" src="https://cloud.githubusercontent.com/assets/9373485/22757221/9e8f212a-ee0f-11e6-87c7-c59cfb2d3863.png">


@tekstrand @PascalZajac 